### PR TITLE
feat: brand aligned custom Giscus comments

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -27,7 +27,7 @@ export default defineConfig({
 			},
 		},
 		server: {
-			allowedHosts: ["40da-45-250-244-187.ngrok-free.app"],
+			allowedHosts: ["*.ngrok-free.app"],
 			watch: {
 				ignored: ["**/.wrangler/**"],
 			},

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -27,6 +27,7 @@ export default defineConfig({
 			},
 		},
 		server: {
+			allowedHosts: ["40da-45-250-244-187.ngrok-free.app"],
 			watch: {
 				ignored: ["**/.wrangler/**"],
 			},

--- a/public/css/giscus.css
+++ b/public/css/giscus.css
@@ -64,24 +64,90 @@ main {
 	--color-primer-shadow-focus: 0 0 0 3px rgba(20, 184, 166, 0.3);
 }
 
-/* Ensure typography and fonts match website theme */
-.giscus,
-.giscus-frame {
+/* ============================================================================
+   IFRAME COMPONENT OVERRIDES
+   Injecting typography, sharp corners, and cyber-teal focus rings into the Giscus iframe.
+   ============================================================================ */
+
+/* Force all text inside Giscus to use the website's technical Monospace typography */
+main,
+input,
+textarea,
+button,
+.giscus-comment,
+.giscus-comments,
+.giscus-reactions,
+.btn,
+.Link--primary,
+.Link--secondary {
 	font-family:
 		"JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace !important;
 }
 
-/* Styling links inside Giscus */
-.giscus .Link--primary,
-.giscus .Link--secondary {
-	transition: color 0.15s ease;
+/* Remove all rounded corners to match the sharp technical terminal aesthetic */
+.Box,
+.Box-header,
+.Box-footer,
+.form-control,
+.btn,
+.giscus-comment,
+.giscus-comment-box,
+.timeline-comment,
+.timeline-comment-group {
+	border-radius: 0px !important;
 }
-.giscus .Link--primary:hover,
-.giscus .Link--secondary:hover {
+
+/* Style the textarea and input elements inside Giscus */
+.form-control {
+	background-color: #0d0f14 !important;
+	border: 1px solid #1f2937 !important;
+	color: #f3f4f6 !important;
+	transition:
+		border-color 0.2s ease,
+		box-shadow 0.2s ease !important;
+}
+
+/* Cyber-Teal glow on focus for all inputs and textareas */
+.form-control:focus {
+	border-color: #14b8a6 !important;
+	box-shadow: 0 0 0 1px #14b8a6 !important;
+	outline: none !important;
+}
+
+/* Styling links inside Giscus to hover with Cyber-Teal */
+.Link--primary,
+.Link--secondary {
+	transition: color 0.15s ease !important;
+}
+
+.Link--primary:hover,
+.Link--secondary:hover {
 	color: #14b8a6 !important;
 }
 
-/* Customize comments container padding and general spacing */
-.giscus .giscus-comments {
-	margin-top: 2rem;
+/* Premium styling for primary buttons (e.g. "Sign in with GitHub" or submit button) */
+.btn-primary {
+	text-transform: uppercase !important;
+	letter-spacing: 0.05em !important;
+	font-weight: 600 !important;
+	background-color: #14b8a6 !important;
+	color: #07080a !important;
+	border: 1px solid #14b8a6 !important;
+	transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1) !important;
+}
+
+.btn-primary:hover:not([disabled]) {
+	background-color: #0d9488 !important;
+	border-color: #0d9488 !important;
+	color: #07080a !important;
+}
+
+.btn-primary:active:not([disabled]) {
+	background-color: #0f766e !important;
+	border-color: #0f766e !important;
+}
+
+/* Customize comments container padding and spacing */
+.giscus-comments {
+	margin-top: 2rem !important;
 }

--- a/src/components/Giscus.astro
+++ b/src/components/Giscus.astro
@@ -25,17 +25,14 @@
 
 <script is:inline>
 	function initGiscus() {
-		// During local development, the Giscus server cannot fetch a stylesheet from localhost.
-		// Therefore, we fall back to a built-in clean transparent theme ('transparent_dark').
-		// Once you deploy the custom CSS to production, Giscus will load it perfectly,
-		// even when previewing on localhost!
 		const isLocal =
-			window.location.hostname === "localhost" ||
-			window.location.hostname === "127.0.0.1";
+			window.location.hostname.includes("localhost") ||
+			window.location.hostname.includes("127.0.0.1") ||
+			window.location.hostname.includes("ngrok");
 
 		const theme = isLocal
-			? "transparent_dark"
-			: "https://arnabxd.me/css/giscus.css";
+			? "https://cdn.jsdelivr.net/gh/ArnabXD/arnabxd.me@preview/public/css/giscus.css?v=1.1.0"
+			: "https://arnabxd.me/css/giscus.css?v=1.1.0";
 
 		const script = document.createElement("script");
 		script.src = "https://giscus.app/client.js";


### PR DESCRIPTION
This PR replaces the default Giscus transparent dark fallback theme with a fully brand-aligned, sharp-cornered monospace custom theme that matches the site's dark cyberpunk aesthetic. Removes legacy debug comments and adds resilient CORS and ngrok-friendly loading.